### PR TITLE
Reduce ANSI resets to allow for more formatter flexibility

### DIFF
--- a/test/tablet/compact_style_test.exs
+++ b/test/tablet/compact_style_test.exs
@@ -21,15 +21,15 @@ defmodule Tablet.CompactStyleTest do
     expected = [
       :underline,
       "key_1",
-      :reset,
+      :no_underline,
       "  ",
       :underline,
       "key_2",
-      :reset,
+      :no_underline,
       "  ",
       :underline,
       "key_3",
-      :reset,
+      :no_underline,
       "  \n" <> "1,1    1,2    1,3    \n" <> "2,1    2,2    2,3    \n"
     ]
 

--- a/test/tablet/ledger_style_test.exs
+++ b/test/tablet/ledger_style_test.exs
@@ -22,17 +22,17 @@ defmodule Tablet.LedgerStyleTest do
       :light_blue_background,
       :black,
       "key_1  key_2  key_3  ",
-      :reset,
+      :default_color,
       "\n",
       :light_black_background,
       :white,
       "1,1    1,2    1,3    ",
-      :reset,
+      :default_color,
       "\n",
       :white_background,
       :black,
       "2,1    2,2    2,3    ",
-      :reset,
+      :default_color,
       "\n"
     ]
 

--- a/test/tablet_test.exs
+++ b/test/tablet_test.exs
@@ -118,15 +118,15 @@ defmodule TabletTest do
     expected = [
       :underline,
       ":name",
-      :reset,
+      :no_underline,
       "  ",
       :underline,
       ":age",
-      :reset,
+      :no_underline,
       "  ",
       :underline,
       ":favorite_food",
-      :reset,
+      :no_underline,
       "  \nBob    10    Spaghetti       \nSteve  11                    \nAmy    12    Grilled Cheese  \n"
     ]
 


### PR DESCRIPTION
The gratuitous resets were making some formatter hacks harder.
