### PR TITLE
Add justificationa and fix truncation bugs

### DIFF
--- a/lib/tablet/styles.ex
+++ b/lib/tablet/styles.ex
@@ -40,14 +40,14 @@ defmodule Tablet.Styles do
   defp compact_header(table, header) do
     Enum.map(header, fn {c, v} ->
       width = table.column_widths[c]
-      [:underline, Tablet.left_trim_pad(v, width), :no_underline, "  "]
+      [:underline, Tablet.fit_to_width(v, width, :left), :no_underline, "  "]
     end)
   end
 
   defp compact_row(table, row) do
     Enum.map(row, fn {c, v} ->
       width = table.column_widths[c]
-      Tablet.left_trim_pad(v, width + 2)
+      Tablet.fit_to_width(v, width + 2, :left)
     end)
   end
 
@@ -85,7 +85,7 @@ defmodule Tablet.Styles do
   defp markdown_row(table, row) do
     Enum.map(row, fn {c, v} ->
       width = table.column_widths[c]
-      ["| ", Tablet.left_trim_pad(v, width), " "]
+      ["| ", Tablet.fit_to_width(v, width, :left), " "]
     end)
   end
 
@@ -193,7 +193,7 @@ defmodule Tablet.Styles do
       |> List.flatten()
       |> Enum.map(fn {c, v} ->
         width = table.column_widths[c]
-        [" ", Tablet.left_trim_pad(v, width), " ", vertical]
+        [" ", Tablet.fit_to_width(v, width, :left), " ", vertical]
       end)
 
     [vertical, items, "\n"]
@@ -251,7 +251,7 @@ defmodule Tablet.Styles do
   defp ledger_row(table, row) do
     Enum.map(row, fn {c, v} ->
       width = table.column_widths[c]
-      [" ", Tablet.left_trim_pad(v, width), " "]
+      [" ", Tablet.fit_to_width(v, width, :left), " "]
     end)
   end
 end

--- a/test/tablet_test.exs
+++ b/test/tablet_test.exs
@@ -222,4 +222,54 @@ defmodule TabletTest do
     assert Tablet.visual_length("🇫🇷") == 2
     assert Tablet.visual_length("😀 👻 🐭") == 8
   end
+
+  defp ftw(ansidata, len, justification) do
+    Tablet.fit_to_width(ansidata, len, justification) |> Tablet.simplify()
+  end
+
+  describe "fit_to_width/3" do
+    test "string trims" do
+      assert ftw("Hello", 5, :left) == ["Hello"]
+      assert ftw("Hello", 4, :left) == ["Hel…"]
+      assert ftw("Hello", 2, :left) == ["H…"]
+      assert ftw("Hello", 1, :left) == ["…"]
+      assert ftw("Hello", 0, :left) == []
+      assert ftw("José", 3, :left) == ["Jo…"]
+    end
+
+    test "unicode trims" do
+      assert ftw("😀 👻 🐭", 8, :left) == ["😀 👻 🐭"]
+      assert ftw("😀 👻 🐭", 7, :left) == ["😀 👻 …"]
+      assert ftw("😀 👻 🐭", 1, :left) == ["…"]
+      assert ftw("😀 👻 🐭", 0, :left) == []
+    end
+
+    test "ansidata trims" do
+      s = [:red, "He", "l", [:green | "lo"]]
+      assert ftw(s, 5, :left) == [:red, "Hel", :green, "lo"]
+      assert ftw(s, 4, :left) == [:red, "Hel", :green, "…"]
+      assert ftw(s, 3, :left) == [:red, "He…", :green]
+      assert ftw(s, 2, :left) == [:red, "H…", :green]
+      assert ftw(s, 1, :left) == [:red, "…", :green]
+      assert ftw(s, 0, :left) == [:red, :green]
+    end
+
+    test "left justifies" do
+      assert ftw("Hello", 10, :left) == ["Hello     "]
+      assert ftw("José", 10, :left) == ["José      "]
+      assert ftw("😀 👻 🐭", 10, :left) == ["😀 👻 🐭  "]
+    end
+
+    test "right justifies" do
+      assert ftw("Hello", 10, :right) == ["     Hello"]
+      assert ftw("José", 10, :right) == ["      José"]
+      assert ftw("😀 👻 🐭", 10, :right) == ["  😀 👻 🐭"]
+    end
+
+    test "center justifies" do
+      assert ftw("Hello", 10, :center) == ["  Hello   "]
+      assert ftw("José", 10, :center) == ["   José   "]
+      assert ftw("😀 👻 🐭", 10, :center) == [" 😀 👻 🐭 "]
+    end
+  end
 end


### PR DESCRIPTION
This renames left_trim_pad/2 to fit_to_width/3 to better describe what
it does now that it handles right and center justification. This is
backwards incompatible.

The previous hack of adding `\b` characters to trim strings was removed.
In addition to being ugly, it did the wrong thing on some inputs. This
also adds unit tests to catch these cases in the future.
