### PR TITLE
Allow style to change everything

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ to use the default conversion.
 
 ## Styling
 
-Various table output styles are supported by passing an atom or 3-arity
+Various table output styles are supported by passing an atom or 1-arity
 function to the  `:style` parameter.
 
 See the [Style Gallery](gallery.md) for the built-in styles.

--- a/create_gallery.exs
+++ b/create_gallery.exs
@@ -11,9 +11,9 @@ Mix.install([{:tablet, path: "."}])
 defmodule Gallery do
   def styles() do
     Tablet.Styles.__info__(:functions)
-    |> Enum.filter(fn {_name, arity} -> arity == 3 end)
+    |> Enum.filter(fn {_name, arity} -> arity == 1 end)
     |> Enum.map(&elem(&1, 0))
-    |> Enum.reject(fn name -> name in [:generic_box] end)
+    |> Enum.reject(fn name -> name in [:generic_box, :resolve] end)
     |> Enum.sort()
   end
 
@@ -98,7 +98,7 @@ defmodule Gallery do
 
   defp style_docs(style) do
     with {_, _, _, _, _, _, function_docs} <- Code.fetch_docs(Tablet.Styles),
-         {_, _, _, %{"en" => docs}, _} <- List.keyfind(function_docs, {:function, style, 3}, 0) do
+         {_, _, _, %{"en" => docs}, _} <- List.keyfind(function_docs, {:function, style, 1}, 0) do
       # Trim the first to lines to not repeat the title
       docs |> String.split("\n") |> Enum.drop(2) |> Enum.join("\n")
     else

--- a/lib/tablet/styles.ex
+++ b/lib/tablet/styles.ex
@@ -24,16 +24,16 @@ defmodule Tablet.Styles do
   """
   @spec compact(Tablet.t(), Tablet.styling_context(), [IO.ANSI.ansidata()]) ::
           IO.ANSI.ansidata()
-  def compact(table, %{line: :header}, rows) do
+  def compact(table, %{line: :header}, content) do
     [
       compact_title(table),
-      rows |> Enum.map(&compact_header(table, &1)) |> Enum.intersperse("   "),
+      content |> Enum.map(&compact_header(table, &1)) |> Enum.intersperse("   "),
       "\n"
     ]
   end
 
-  def compact(table, %{line: n}, rows) when is_integer(n) do
-    [rows |> Enum.map(&compact_row(table, &1)) |> Enum.intersperse("   "), "\n"]
+  def compact(table, %{line: n}, content) when is_integer(n) do
+    [content |> Enum.map(&compact_row(table, &1)) |> Enum.intersperse("   "), "\n"]
   end
 
   def compact(_table, _context, _row) do
@@ -71,12 +71,12 @@ defmodule Tablet.Styles do
   Pass `style: :markdown` to `Tablet.puts/2` or `Tablet.render/2` to use.
   """
   @spec markdown(Tablet.t(), Tablet.styling_context(), [IO.ANSI.ansidata()]) :: IO.ANSI.ansidata()
-  def markdown(table, %{line: :header}, rows) do
+  def markdown(table, %{line: :header}, content) do
     [
       markdown_title(table),
-      rows |> Enum.map(&markdown_row(table, &1)),
+      content |> Enum.map(&markdown_row(table, &1)),
       "|\n",
-      rows
+      content
       |> List.flatten()
       |> Enum.map(fn {c, _v} ->
         width = table.column_widths[c]
@@ -86,8 +86,8 @@ defmodule Tablet.Styles do
     ]
   end
 
-  def markdown(table, %{line: n}, rows) when is_integer(n) do
-    [rows |> Enum.map(&markdown_row(table, &1)), "|\n"]
+  def markdown(table, %{line: n}, content) when is_integer(n) do
+    [content |> Enum.map(&markdown_row(table, &1)), "|\n"]
   end
 
   def markdown(_table, _context, _row) do
@@ -114,7 +114,7 @@ defmodule Tablet.Styles do
   To use, pass `style: :box` to `Tablet.puts/2` or `Tablet.render/2`.
   """
   @spec box(Tablet.t(), Tablet.styling_context(), [IO.ANSI.ansidata()]) :: IO.ANSI.ansidata()
-  def box(table, context, rows) do
+  def box(table, context, content) do
     border = %{
       h: "─",
       v: "|",
@@ -131,7 +131,7 @@ defmodule Tablet.Styles do
 
     new_context = Map.put(context, :border, border)
 
-    generic_box(table, new_context, rows)
+    generic_box(table, new_context, content)
   end
 
   @doc """
@@ -144,7 +144,7 @@ defmodule Tablet.Styles do
   """
   @spec unicode_box(Tablet.t(), Tablet.styling_context(), [IO.ANSI.ansidata()]) ::
           IO.ANSI.ansidata()
-  def unicode_box(table, context, rows) do
+  def unicode_box(table, context, content) do
     border = %{
       h: "─",
       v: "│",
@@ -161,7 +161,7 @@ defmodule Tablet.Styles do
 
     new_context = Map.put(context, :border, border)
 
-    generic_box(table, new_context, rows)
+    generic_box(table, new_context, content)
   end
 
   @doc """
@@ -185,17 +185,17 @@ defmodule Tablet.Styles do
   """
   @spec generic_box(Tablet.t(), Tablet.styling_context(), [IO.ANSI.ansidata()]) ::
           IO.ANSI.ansidata()
-  def generic_box(table, %{line: :header, border: border}, rows) do
+  def generic_box(table, %{line: :header, border: border}, content) do
     [
-      generic_box_title(table, border, rows),
-      generic_box_row(table, rows, border.v)
+      generic_box_title(table, border, content),
+      generic_box_row(table, content, border.v)
     ]
   end
 
-  def generic_box(table, %{line: line, border: border}, rows) when is_integer(line) do
+  def generic_box(table, %{line: line, border: border}, content) when is_integer(line) do
     [
-      generic_box_border(table, rows, border.l, border.c, border.r, border.h),
-      generic_box_row(table, rows, border.v)
+      generic_box_border(table, content, border.l, border.c, border.r, border.h),
+      generic_box_row(table, content, border.v)
     ]
   end
 
@@ -203,17 +203,17 @@ defmodule Tablet.Styles do
     generic_box_border(table, row, border.ll, border.lc, border.lr, border.h)
   end
 
-  defp generic_box_title(%{name: []} = table, border, rows) do
-    generic_box_border(table, rows, border.ul, border.uc, border.ur, border.h)
+  defp generic_box_title(%{name: []} = table, border, content) do
+    generic_box_border(table, content, border.ul, border.uc, border.ur, border.h)
   end
 
-  defp generic_box_title(table, border, rows) do
+  defp generic_box_title(table, border, content) do
     w = interior_width(table, 2, 1, 1)
 
     [
       [border.ul, String.duplicate(border.h, w), border.ur, "\n"],
       [border.v, Tablet.fit_to_width(table.name, w, :center), border.v, "\n"],
-      generic_box_border(table, rows, border.l, border.uc, border.r, border.h)
+      generic_box_border(table, content, border.l, border.uc, border.r, border.h)
     ]
   end
 
@@ -261,25 +261,25 @@ defmodule Tablet.Styles do
   To use, pass `style: :ledger` to `Tablet.puts/2` or `Tablet.render/2`.
   """
   @spec ledger(Tablet.t(), Tablet.styling_context(), [IO.ANSI.ansidata()]) :: IO.ANSI.ansidata()
-  def ledger(table, %{line: :header}, rows) do
+  def ledger(table, %{line: :header}, content) do
     [
       :light_blue_background,
       :black,
       ledger_title(table),
-      rows |> Enum.map(&ledger_row(table, &1)) |> Enum.intersperse(" "),
+      content |> Enum.map(&ledger_row(table, &1)) |> Enum.intersperse(" "),
       :default_background,
       :default_color,
       "\n"
     ]
   end
 
-  def ledger(table, %{line: n}, rows) when is_integer(n) do
+  def ledger(table, %{line: n}, content) when is_integer(n) do
     color =
       if rem(n, 2) == 0, do: [:white_background, :black], else: [:light_black_background, :white]
 
     [
       color,
-      rows |> Enum.map(&ledger_row(table, &1)) |> Enum.intersperse(" "),
+      content |> Enum.map(&ledger_row(table, &1)) |> Enum.intersperse(" "),
       :default_background,
       :default_color,
       "\n"

--- a/lib/tablet/styles.ex
+++ b/lib/tablet/styles.ex
@@ -24,7 +24,7 @@ defmodule Tablet.Styles do
   """
   @spec compact(Tablet.t(), Tablet.styling_context(), [IO.ANSI.ansidata()]) ::
           IO.ANSI.ansidata()
-  def compact(table, %{line: :header}, content) do
+  def compact(table, %{section: :header}, content) do
     [
       compact_title(table),
       content |> Enum.map(&compact_header(table, &1)) |> Enum.intersperse("   "),
@@ -32,7 +32,7 @@ defmodule Tablet.Styles do
     ]
   end
 
-  def compact(table, %{line: n}, content) when is_integer(n) do
+  def compact(table, %{section: :body}, content) do
     [content |> Enum.map(&compact_row(table, &1)) |> Enum.intersperse("   "), "\n"]
   end
 
@@ -71,7 +71,7 @@ defmodule Tablet.Styles do
   Pass `style: :markdown` to `Tablet.puts/2` or `Tablet.render/2` to use.
   """
   @spec markdown(Tablet.t(), Tablet.styling_context(), [IO.ANSI.ansidata()]) :: IO.ANSI.ansidata()
-  def markdown(table, %{line: :header}, content) do
+  def markdown(table, %{section: :header}, content) do
     [
       markdown_title(table),
       content |> Enum.map(&markdown_row(table, &1)),
@@ -86,7 +86,7 @@ defmodule Tablet.Styles do
     ]
   end
 
-  def markdown(table, %{line: n}, content) when is_integer(n) do
+  def markdown(table, %{section: :body}, content) do
     [content |> Enum.map(&markdown_row(table, &1)), "|\n"]
   end
 
@@ -185,21 +185,21 @@ defmodule Tablet.Styles do
   """
   @spec generic_box(Tablet.t(), Tablet.styling_context(), [IO.ANSI.ansidata()]) ::
           IO.ANSI.ansidata()
-  def generic_box(table, %{line: :header, border: border}, content) do
+  def generic_box(table, %{section: :header, border: border}, content) do
     [
       generic_box_title(table, border, content),
       generic_box_row(table, content, border.v)
     ]
   end
 
-  def generic_box(table, %{line: line, border: border}, content) when is_integer(line) do
+  def generic_box(table, %{section: :body, border: border}, content) do
     [
       generic_box_border(table, content, border.l, border.c, border.r, border.h),
       generic_box_row(table, content, border.v)
     ]
   end
 
-  def generic_box(table, %{line: :footer, border: border}, row) do
+  def generic_box(table, %{section: :footer, border: border}, row) do
     generic_box_border(table, row, border.ll, border.lc, border.lr, border.h)
   end
 
@@ -261,7 +261,7 @@ defmodule Tablet.Styles do
   To use, pass `style: :ledger` to `Tablet.puts/2` or `Tablet.render/2`.
   """
   @spec ledger(Tablet.t(), Tablet.styling_context(), [IO.ANSI.ansidata()]) :: IO.ANSI.ansidata()
-  def ledger(table, %{line: :header}, content) do
+  def ledger(table, %{section: :header}, content) do
     [
       :light_blue_background,
       :black,
@@ -273,9 +273,9 @@ defmodule Tablet.Styles do
     ]
   end
 
-  def ledger(table, %{line: n}, content) when is_integer(n) do
+  def ledger(table, %{section: :body, row: n}, content) do
     color =
-      if rem(n, 2) == 0, do: [:white_background, :black], else: [:light_black_background, :white]
+      if rem(n, 2) == 1, do: [:white_background, :black], else: [:light_black_background, :white]
 
     [
       color,

--- a/test/tablet_test.exs
+++ b/test/tablet_test.exs
@@ -81,12 +81,12 @@ defmodule TabletTest do
 
     data = generate_table(5, 2)
     assert_raise ArgumentError, fn -> Tablet.render(data, column_widths: 123) end
-    assert_raise ArgumentError, fn -> Tablet.render(data, context: []) end
     assert_raise ArgumentError, fn -> Tablet.render(data, default_column_width: :hello) end
     assert_raise ArgumentError, fn -> Tablet.render(data, formatter: "nope") end
     assert_raise ArgumentError, fn -> Tablet.render(data, keys: 1) end
     assert_raise ArgumentError, fn -> Tablet.render(data, style: "yolo") end
     assert_raise ArgumentError, fn -> Tablet.render(data, style: :invalid) end
+    assert_raise ArgumentError, fn -> Tablet.render(data, style_options: nil) end
     assert_raise ArgumentError, fn -> Tablet.render(data, total_width: -1) end
     assert_raise ArgumentError, fn -> Tablet.render(data, wrap_across: 0) end
   end
@@ -94,6 +94,24 @@ defmodule TabletTest do
   test "compact style can be specified" do
     data = [%{id: 1, name: "Puck"}, %{id: 2, name: "Nick Bottom"}]
     output = capture_io(fn -> Tablet.puts(data, style: :compact, ansi_enabled?: false) end)
+
+    expected = """
+    :id  :name
+    1    Puck
+    2    Nick Bottom
+    """
+
+    assert removes_trailing_spaces(output) == expected
+  end
+
+  test "compact style can be specified as function" do
+    # Users should specify as an atom, but this checks that passing functions works
+    data = [%{id: 1, name: "Puck"}, %{id: 2, name: "Nick Bottom"}]
+
+    output =
+      capture_io(fn ->
+        Tablet.puts(data, style: &Tablet.Styles.compact/1, ansi_enabled?: false)
+      end)
 
     expected = """
     :id  :name


### PR DESCRIPTION
This has several changes, but the main idea is to allow
styles to do more things so that their implementation can
be simplified.

- **Try to improve naming in prep for multi-line**
- **Simplify style context for easier match**
- **Allow styling functions to change everything**
